### PR TITLE
feat: Switch to using JSON Pointer strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Test
+      run: |
+        go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/ahume/go-yamedit
 
-require (
-	github.com/ghodss/yaml v1.0.0
-	github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e
-	gopkg.in/yaml.v2 v2.2.2 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2
-)
+go 1.14
 
-go 1.13
+require (
+	github.com/qri-io/jsonpointer v0.1.0
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+)

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e h1:ZZCvgaRDZg1gC9/1xrsgaJzQUCQgniKtw0xjWywWAOE=
-github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e/go.mod h1:+rHyWac2R9oAZwFe1wGY2HBzFJJy++RHBg1cU23NkD8=
+github.com/qri-io/jsonpointer v0.1.0 h1:OcTtTmorodUCRc2CZhj/ZwOET8zVj6uo0ArEmzoThZI=
+github.com/qri-io/jsonpointer v0.1.0/go.mod h1:DnJPaYgiKu56EuDp8TU5wFLdZIcAnb/uH9v37ZaMV64=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2 h1:XZx7nhd5GMaZpmDaEHFVafUZC7ya0fuo7cSJ3UCKYmM=
-gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/yamedit_test.go
+++ b/yamedit_test.go
@@ -1,0 +1,137 @@
+package yamedit_test
+
+import (
+	"testing"
+
+	"github.com/ahume/go-yamedit"
+)
+
+func TestGet(t *testing.T) {
+	yaml := `foo:
+  bar: you
+  anno:
+    a.b.c/123: right
+  brain:
+  - 1
+  - two
+  - three:
+    foo: bar`
+
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "/foo/bar", want: "you"},
+		{path: "/foo/brain/0", want: "1"},
+		{path: "/foo/brain/2/foo", want: "bar"},
+		{path: "/foo/anno/a.b.c~1123", want: "right"},
+	}
+
+	for _, tc := range tests {
+		r, err := yamedit.Get([]byte(yaml), tc.path)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if r != tc.want {
+			t.Errorf("did not correct value. want: %s, got: %s", tc.want, r)
+		}
+	}
+}
+
+func TestEdit(t *testing.T) {
+	yaml := `foo:
+  bar: you
+  anno:
+    a.b.c/123: right
+  data:
+    config.json: |
+      line1
+      line2
+  brain:
+  - zero
+  - one
+  - two:
+    foo: bar`
+
+	tests := []struct {
+		path     string
+		newValue string
+		want     string
+	}{
+		{path: "/foo/bar", newValue: "fool", want: `foo:
+  bar: fool
+  anno:
+    a.b.c/123: right
+  data:
+    config.json: |
+      line1
+      line2
+  brain:
+  - zero
+  - one
+  - two:
+    foo: bar`},
+		{path: "/foo/brain/1", newValue: "fool", want: `foo:
+  bar: you
+  anno:
+    a.b.c/123: right
+  data:
+    config.json: |
+      line1
+      line2
+  brain:
+  - zero
+  - fool
+  - two:
+    foo: bar`},
+		{path: "/foo/brain/2/foo", newValue: "fool", want: `foo:
+  bar: you
+  anno:
+    a.b.c/123: right
+  data:
+    config.json: |
+      line1
+      line2
+  brain:
+  - zero
+  - one
+  - two:
+    foo: fool`},
+		{path: "/foo/anno/a.b.c~1123", newValue: "left", want: `foo:
+  bar: you
+  anno:
+    a.b.c/123: left
+  data:
+    config.json: |
+      line1
+      line2
+  brain:
+  - zero
+  - one
+  - two:
+    foo: bar`},
+		{path: "/foo/data/config.json", newValue: `>
+      {"ok":"then"}`, want: `foo:
+  bar: you
+  anno:
+    a.b.c/123: right
+  data:
+    config.json: >
+      {"ok":"then"}
+  brain:
+  - zero
+  - one
+  - two:
+    foo: bar`},
+	}
+
+	for _, tc := range tests {
+		r, err := yamedit.Edit([]byte(yaml), tc.path, tc.newValue)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if string(r) != tc.want {
+			t.Errorf("did not correct value. \nWANT:\n-------- \n%s \nGOT:\n-------- \n%s", tc.want, r)
+		}
+	}
+}


### PR DESCRIPTION
The driver for this is to be able to support yaml fields like
annotations:
  ingress.k8s.io/something: here

To update the value "here"  we need to be able to specify a key with
slashes and dots in it. It turns out there is an existing spec for
this called JSON Pointer. https://tools.ietf.org/html/rfc6901

---------

From a BW perspective @jimmyfielding - this will involve switching all oobs
that specify a path from dot notation to slash notation. But this
isn't as many as you might think, as most use the special case
"container" field which the `oob` command replaces with the correct
path to the image field.